### PR TITLE
Fix response content-type= application/json

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func handler() http.Handler {
 	root := http.NewServeMux()
 	root.Handle("/wd/hub/", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
 			r.URL.Scheme = "http"
 			r.URL.Host = (&request{r}).localaddr()
 			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/wd/hub")


### PR DESCRIPTION
According to [WebDriver wire protocol](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#responses) as well as [w3c webdriver spec](https://www.w3.org/TR/webdriver/#processing-model), all valid responses should have `content-type="application/json"` header.
Currently, content-type="text/plain" for /wd/hub endpoint, and selenium-webdriver ruby gem fails because of this.
This PR fixes the issue. 